### PR TITLE
Fix names in package; improve UX for neighbor_voting

### DIFF
--- a/EGAD/DESCRIPTION
+++ b/EGAD/DESCRIPTION
@@ -3,13 +3,13 @@ Type: Package
 Title: Extending guilt by association by degree
 Version: 0.99.0
 Date: 2016-04-20
-Authors@R: c(person("Sara Ballouz", "Developer", role = c("aut", "cre"),
+Authors@R: c(person(given="Sara", family= "Ballouz", role = c("aut", "cre"),
          email = "sballouz@cshl.edu"),
-         person("Melanie Weber", "Developer", role = c("aut","ctb"),
+         person(given="Melanie", family="Weber", role = c("aut","ctb"),
 	      		email = "melweber@t-online.de"),
-	      person("Paul Pavlidis", "Author", role = "aut",
+	      person(given="Paul", family="Pavlidis", role = "aut",
 	      		email = "paul@chibi.ubc.ca"),
-	      person("Jesse Gillis", "Author", role = c("aut","ctb"),
+	      person(given="Jesse", family="Gillis", role = c("aut","ctb"),
 		     email = "jgillis@cshl.edu"))
 Description: The package implements a series of highly efficient tools
               to calculate functional properties of networks based on

--- a/EGAD/R/neighbor_voting.R
+++ b/EGAD/R/neighbor_voting.R
@@ -10,7 +10,11 @@
 #' @param output string, default is AUROC  
 #' @param FLAG_DRAW binary flag to draw roc plot
 #'
-#' @return scores numeric matrix  
+#' @return scores numeric matrix with a row for each gene label and columns
+#'         auc: the average area under the ROC or PR curve for the neighbor voting predictor
+#'              across cross validation replicates
+#'         avg_node_degree: the average node degree
+#'         degree_null_auc: the area the ROC or PR curve for the node degree predictor
 #' 
 #' @keywords neighbor voting 
 #' guilt by association 
@@ -149,7 +153,10 @@ neighbor_voting <- function(genes.labels, network, nFold = 3, output = "AUROC", 
             plot_roc_overlay(predicts, test.genes.labels)
         }
         
-        scores <- cbind(rocN, matrix(average_node_degree)[, 1], roc)
+        scores <- cbind(
+            auc=rocN,
+            avg_node_degree=matrix(average_node_degree)[, 1],
+            degree_null_auc=roc)
     } else if (output == "PR") {
         
         
@@ -188,7 +195,10 @@ neighbor_voting <- function(genes.labels, network, nFold = 3, output = "AUROC", 
         # print('Calculate node degree - average')
         average_node_degree <- t(temp)/colsums
         
-        scores <- cbind(auprc, matrix(average_node_degree)[, 1], auprc.null)
+        scores <- cbind(
+            auc=auprc,
+            avg_node_degree=matrix(average_node_degree)[, 1],
+            degree_null_auc=auprc.null)
     }
     
     return(scores)


### PR DESCRIPTION
If you look in Bioconductor, 

```
https://www.bioconductor.org/packages/devel/bioc/html/EGAD.html
```

you can see the format for the person() names in DESCRIPTIONS is wrong, which makes citing the package a problem.

Also, I tried to make the documentation and output format for `neighbor_voting` slightly clearer. I'm not sure I've gotten the names for the output variables right but I'm not sure what they should be instead.
